### PR TITLE
feat: Fixing MP Commands constructor (Area code is not set)

### DIFF
--- a/Model/Console/Command/Notification/CheckoutProAddChildPayment.php
+++ b/Model/Console/Command/Notification/CheckoutProAddChildPayment.php
@@ -11,6 +11,7 @@ namespace MercadoPago\AdbPayment\Model\Console\Command\Notification;
 use Exception;
 use Magento\Payment\Model\Method\Logger;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\OrderFactory;
 use Magento\Sales\Model\Order\Payment\Transaction;
 use MercadoPago\AdbPayment\Model\Console\Command\AbstractModel;
 
@@ -25,17 +26,17 @@ class CheckoutProAddChildPayment extends AbstractModel
     protected $logger;
 
     /**
-     * @var Order
+     * @var OrderFactory
      */
     protected $order;
 
     /**
      * @param Logger $logger
-     * @param Order  $order
+     * @param OrderFactory  $order
      */
     public function __construct(
         Logger $logger,
-        Order $order
+        OrderFactory $order
     ) {
         parent::__construct(
             $logger

--- a/Model/Console/Command/Notification/FetchStatus.php
+++ b/Model/Console/Command/Notification/FetchStatus.php
@@ -10,7 +10,7 @@ namespace MercadoPago\AdbPayment\Model\Console\Command\Notification;
 
 use Exception;
 use Magento\Payment\Model\Method\Logger;
-use Magento\Sales\Model\Order;
+use Magento\Sales\Model\OrderFactory;
 use MercadoPago\AdbPayment\Model\Console\Command\AbstractModel;
 
 /**
@@ -24,17 +24,17 @@ class FetchStatus extends AbstractModel
     protected $logger;
 
     /**
-     * @var Order
+     * @var OrderFactory
      */
     protected $order;
 
     /**
      * @param Logger $logger
-     * @param Order  $order
+     * @param OrderFactory  $order
      */
     public function __construct(
         Logger $logger,
-        Order $order
+        OrderFactory $order
     ) {
         parent::__construct(
             $logger


### PR DESCRIPTION
Fixing -Area code is not set- issue

refs: #main

## 📝 Description

The purpose of this PR is to fix an issue when installing this module and then executing bin/magento setup:upgrade


## 🎯 Objetivos do PR

This is a fix for "Area code is not set" message.

Some custom MP commands needs to change the use of Magento\Sales\Model\Order to Magento\Sales\Model\OrderFactory

## 📸 Screenshots

![image](https://github.com/mercadopago/adb-payment/assets/3485613/d5238a06-ba93-4523-a8a7-295829ebf8a6)

## 🧰 How to reproduce

1. Adobe Commerce 2.4.6-p3
2. Install MP via composer -> composer require "mercadopago/adb-payment"
3. Execute bin/magento setup:upgrade


## 🔀 PRs relacionados
[> - #123
> - #321](https://github.com/mercadopago/adb-payment/pull/7)
-->
