### PR TITLE
Dependency issue fixed when MP Method load checkout page

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -12,9 +12,13 @@ let config = {
     },
     shim: {
         'mercadoPagoSkdJs': {
+            'exports': 'MercadoPago',
             'deps': ['jquery']
         }
     },
+    deps: [
+        'initMPCheckout'
+    ],
     config: {
         mixins: {
             'mage/validation': {


### PR DESCRIPTION
## 📝 Descrição

Add dependency for MercadoPago in requirejs-config
We had some checkout page issue when MP method loading for first time.
Reviewing the code we found initMPCheckout return null bc sdk still loading and requestJS execute define until sdk finished.
adding deps we 100% sure module will be executed until initMPCheckout finished.

Por favor, verifique o tipo de mudança que seu PR introduz:

- [ ✅ ] Correção de bug
- [ ] Feature
- [ ] Atualização de Lib e dependências
- [ ] Atualização de estilo de código (formatação, renomeação)
- [ ] Refatoração (sem alterações funcionais, sem alterações de API)
- [ ] Alterações no conteúdo da documentação
- [ ] Correção de vulnerabilidade
- [ ] Testes E2E
- [ ] Outro (descreva):

## 🚨 Checklist

- [ ] Código compila corretamente
- [ ] Testes criados que falham sem a alteração (se possível)
- [ ] Todos os testes passando
- [ ] Atualizar o README / CHANGELOG / Documentação / Swagger / Fury Docs / Confluence (se necessário)

## 🧰 Qual é o comportamento atual?