### PR TITLE
fix: PHP 8.5 / Magento 2.4.9 compatibility in console commands and ga…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- PHP 8.5 / Magento 2.4.9 compatibility: declared `int` return type on console command `execute()` methods and replaced the deprecated `(double)` cast with `(float)` in `Gateway/Request/TransactionInfoDataRequest.php`.
+
+### Changed
+- Console commands now wrap their execution in a try/catch, printing the error and returning `Command::FAILURE` on failure (instead of always returning success).
+
 ## [1.15.4] - 2026-05-12
 ### Added
 - Added user-friendly error message for Credits MLC minimum amount validation

--- a/Console/Command/Adminstrative/FetchMerchantInfo.php
+++ b/Console/Command/Adminstrative/FetchMerchantInfo.php
@@ -53,17 +53,27 @@ class FetchMerchantInfo extends Command
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-    ) {
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
-        $this->fetchMerchant->setOutput($output);
+    ): int {
+        try {
+            $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+            $this->fetchMerchant->setOutput($output);
 
-        $storeId = $input->getArgument(self::STORE_ID);
+            $storeId = $input->getArgument(self::STORE_ID);
 
-        return $this->fetchMerchant->fetch($storeId);
+            $this->fetchMerchant->fetch($storeId);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
     }
 
     /**

--- a/Console/Command/Adminstrative/PaymentExpirations.php
+++ b/Console/Command/Adminstrative/PaymentExpirations.php
@@ -58,18 +58,28 @@ class PaymentExpirations extends Command
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-    ) {
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
-        $this->paymentExpiration->setOutput($output);
+    ): int {
+        try {
+            $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+            $this->paymentExpiration->setOutput($output);
 
-        $preferenceId = $input->getArgument(self::PREFERENCE_ID);
-        $storeId = $input->getArgument(self::STORE_ID);
+            $preferenceId = $input->getArgument(self::PREFERENCE_ID);
+            $storeId = $input->getArgument(self::STORE_ID);
 
-        return $this->paymentExpiration->expire($preferenceId, $storeId);
+            $this->paymentExpiration->expire($preferenceId, $storeId);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
     }
 
     /**

--- a/Console/Command/Notification/CheckoutCreditsAddChild.php
+++ b/Console/Command/Notification/CheckoutCreditsAddChild.php
@@ -11,6 +11,7 @@ namespace MercadoPago\AdbPayment\Console\Command\Notification;
 
 use Magento\Framework\App\State;
 use MercadoPago\AdbPayment\Model\Console\Command\Notification\CheckoutCreditsAddChildPayment;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,18 +50,28 @@ class CheckoutCreditsAddChild extends ChechoutProAddChild
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-    ) {
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
-        $this->checkoutCreditsAddChild->setOutput($output);
+    ): int {
+        try {
+            $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+            $this->checkoutCreditsAddChild->setOutput($output);
 
-        $orderId = $input->getArgument(self::ORDER_ID);
-        $transactionId = $input->getArgument(self::CHILD);
+            $orderId = $input->getArgument(self::ORDER_ID);
+            $transactionId = $input->getArgument(self::CHILD);
 
-        return $this->checkoutCreditsAddChild->add($orderId, $transactionId);
+            $this->checkoutCreditsAddChild->add($orderId, $transactionId);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
     }
 
     /**

--- a/Console/Command/Notification/CheckoutProAddChild.php
+++ b/Console/Command/Notification/CheckoutProAddChild.php
@@ -58,18 +58,28 @@ class CheckoutProAddChild extends Command
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-    ) {
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
-        $this->checkoutProAddChild->setOutput($output);
+    ): int {
+        try {
+            $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+            $this->checkoutProAddChild->setOutput($output);
 
-        $orderId = $input->getArgument(self::ORDER_ID);
-        $transactionId = $input->getArgument(self::CHILD);
+            $orderId = $input->getArgument(self::ORDER_ID);
+            $transactionId = $input->getArgument(self::CHILD);
 
-        return $this->checkoutProAddChild->add($orderId, $transactionId);
+            $this->checkoutProAddChild->add($orderId, $transactionId);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
     }
 
     /**

--- a/Console/Command/Notification/FetchOrderStatus.php
+++ b/Console/Command/Notification/FetchOrderStatus.php
@@ -53,17 +53,27 @@ class FetchOrderStatus extends Command
      *
      * @param InputInterface  $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
     protected function execute(
         InputInterface $input,
         OutputInterface $output
-    ) {
-        $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
-        $this->fetchStatus->setOutput($output);
+    ): int {
+        try {
+            $this->state->setAreaCode(\Magento\Framework\App\Area::AREA_ADMINHTML);
+            $this->fetchStatus->setOutput($output);
 
-        $orderId = $input->getArgument(self::ORDER_ID);
+            $orderId = $input->getArgument(self::ORDER_ID);
 
-        return $this->fetchStatus->fetch($orderId);
+            $this->fetchStatus->fetch($orderId);
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+
+            return Command::FAILURE;
+        }
     }
 
     /**

--- a/Gateway/Request/TransactionInfoDataRequest.php
+++ b/Gateway/Request/TransactionInfoDataRequest.php
@@ -120,7 +120,7 @@ class TransactionInfoDataRequest implements BuilderInterface
 
         for ($i = 0; $i < self::NUM_CARDS; $i++):
             $cardInfo = [
-                self::TRANSACTION_AMOUNT => $this->config->formatPrice((double) $payment->getAdditionalInformation('card_'.$i.'_amount'), $order->getStoreId()),
+                self::TRANSACTION_AMOUNT => $this->config->formatPrice((float) $payment->getAdditionalInformation('card_'.$i.'_amount'), $order->getStoreId()),
                 self::INSTALLMENTS       => (int) $payment->getAdditionalInformation('card_'.$i.'_installments') ?: 1,
                 self::TOKEN              => $payment->getAdditionalInformation('card_'.$i.'_number_token'),
                 self::PAYMENT_METHOD_ID  => strtolower((string) $payment->getAdditionalInformation('card_'.$i.'_type')),


### PR DESCRIPTION
…teway cast

- Declare int return type on console execute() methods (Symfony Console contract).
- Wrap command execution in try/catch: print the error and return Command::FAILURE on failure (previously the commands always returned success).
- Replace deprecated (double) cast with (float) in TransactionInfoDataRequest.

## 📝 Descrição

Por favor, explique as mudanças que você fez aqui.

## 🕵️  Testes

<!-- Adicionada evidência de teste, impressões, como prova ou algo que você pensa em testar seu código -->

## 🎯 Tipo de PR

<!-- Não envie atualizações para as dependências, a menos que isso corrija um problema. -->

<!-- Tente limitar sua solicitação pull a um tipo, envie várias solicitações pull, se necessário. -->

Por favor, verifique o tipo de mudança que seu PR introduz:

- [ ] Correção de bug
- [ ] Feature
- [ ] Atualização de Lib e dependências
- [ ] Atualização de estilo de código (formatação, renomeação)
- [ ] Refatoração (sem alterações funcionais, sem alterações de API)
- [ ] Alterações no conteúdo da documentação
- [ ] Correção de vulnerabilidade
- [ ] Testes E2E
- [ ] Outro (descreva):

## 🚨 Checklist

- [ ] Código compila corretamente
- [ ] Testes criados que falham sem a alteração (se possível)
- [ ] Todos os testes passando
- [ ] Atualizar o README / CHANGELOG / Documentação / Swagger / Fury Docs / Confluence (se necessário)

## 🧰 Qual é o comportamento atual?

<!-- Descreva o comportamento atual que você está modificando ou crie um link para um problema relevante. -->

Link da tarefa: N/A

<!-- Itens opcionais
## 🔗 Links
> - [link1.com](https://)
> - [link2.com](https://)

## 🔀 PRs relacionados
> - #123
> - #321
-->

---

❤️ Obrigado!

Ei revisor! Veja nossos 5 pilares de revisão: https://mercadolibre.atlassian.net/wiki/spaces/PLU/pages/2240021388/Processo+de+Revis+o+de+C+digo
